### PR TITLE
Fix MotionEvent gestures getting stuck in player

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -1695,7 +1695,7 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
                     lastPan = newPan
                 }
 
-                MotionEvent.ACTION_POINTER_UP, MotionEvent.ACTION_UP -> {
+                MotionEvent.ACTION_CANCEL, MotionEvent.ACTION_POINTER_UP, MotionEvent.ACTION_UP -> {
                     // Reset touch
                     lastPan = null
                     currentTouchStart = null
@@ -1777,7 +1777,7 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
                     }
                 }
 
-                MotionEvent.ACTION_UP -> {
+                MotionEvent.ACTION_CANCEL, MotionEvent.ACTION_UP -> {
                     holdhandler.removeCallbacks(holdRunnable)
                     if (hasTriggeredSpeedUp) {
                         player.setPlaybackSpeed(DataStoreHelper.playBackSpeed)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -1660,7 +1660,7 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
         playerBinding?.playerIntroPlay?.isGone = true
 
         // Handle pan with two fingers
-        if ((event.pointerCount == 2 || (lastPan != null && event.actionMasked == MotionEvent.ACTION_CANCEL)) && !isLocked && isFullScreenPlayer && !hasTriggeredSpeedUp && currentTouchAction == null) {
+        if ((event.pointerCount == 2 || lastPan != null) && !isLocked && isFullScreenPlayer && !hasTriggeredSpeedUp && currentTouchAction == null) {
             holdhandler.removeCallbacks(holdRunnable) // remove 2x speed
 
             // Gesture detectors for zoom & pan

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -1660,7 +1660,7 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
         playerBinding?.playerIntroPlay?.isGone = true
 
         // Handle pan with two fingers
-        if (event.pointerCount == 2 && !isLocked && isFullScreenPlayer && !hasTriggeredSpeedUp && currentTouchAction == null) {
+        if ((event.pointerCount == 2 || (lastPan != null && event.actionMasked == MotionEvent.ACTION_CANCEL)) && !isLocked && isFullScreenPlayer && !hasTriggeredSpeedUp && currentTouchAction == null) {
             holdhandler.removeCallbacks(holdRunnable) // remove 2x speed
 
             // Gesture detectors for zoom & pan


### PR DESCRIPTION
Fixes:
* 2x speed sometimes gets stuck enabled
* Zoom frame outline gets stuck on even when not touching screen anymore
* Swipe to fast forward time stamp gets stuck visible on the screen even when gesture has completed

That is fixed by handling `ACTION_CANCEL` which can sometimes get called instead of ever calling `ACTION_UP` or `ACTION_POINTER_UP`. For zoom, it also adds a check if `lastPan` is not null to run those actions because when `ACTION_CANCEL` is triggered there, `event.pointerCount` is not always two. If there is a `lastPan` we can just run it like normal since that means it is still active and we should run those events, in order to stop the action.