### PR TITLE
Add support for using kotlinx-serialization rather than Jackson

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 val javaTarget = JvmTarget.fromTarget(libs.versions.jvmTarget.get())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.dokka) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ juniversalchardet = "2.5.0"
 kotlinGradlePlugin = "2.3.20"
 kotlinxCollectionsImmutable = "0.4.0"
 kotlinxCoroutinesCore = "1.10.2"
-kotlinxSerialization = "1.11.0"
+kotlinxSerializationJson = "1.11.0"
 lifecycleKtx = "2.10.0"
 material = "1.14.0-beta01"
 media3 = "1.9.3"
@@ -84,7 +84,7 @@ junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "junitKtx" }
 juniversalchardet = { module = "com.github.albfernandez:juniversalchardet", version.ref = "juniversalchardet" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycleKtx" }
 lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycleKtx" }
 material = { module = "com.google.android.material:material", version.ref = "material" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ juniversalchardet = "2.5.0"
 kotlinGradlePlugin = "2.3.20"
 kotlinxCollectionsImmutable = "0.4.0"
 kotlinxCoroutinesCore = "1.10.2"
+kotlinxSerialization = "1.11.0"
 lifecycleKtx = "2.10.0"
 material = "1.14.0-beta01"
 media3 = "1.9.3"
@@ -83,6 +84,7 @@ junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "junitKtx" }
 juniversalchardet = { module = "com.github.albfernandez:juniversalchardet", version.ref = "juniversalchardet" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycleKtx" }
 lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycleKtx" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
@@ -125,6 +127,7 @@ buildkonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfigG
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokkaGradlePlugin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm" , version.ref = "kotlinGradlePlugin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlinGradlePlugin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinGradlePlugin" }
 
 [bundles]
 coil = ["coil", "coil-network-okhttp"]

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     alias(libs.plugins.android.multiplatform.library)
     alias(libs.plugins.buildkonfig)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 val javaTarget = JvmTarget.fromTarget(libs.versions.jvmTarget.get())
@@ -57,6 +58,7 @@ kotlin {
             implementation(libs.nicehttp) // HTTP Lib
             implementation(libs.jackson.module.kotlin) // JSON Parser
             implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.serialization.json) // JSON Parser
             implementation(libs.fuzzywuzzy) // Match Extractors
             implementation(libs.jsoup) // HTML Parser
             implementation(libs.rhino) // Run JavaScript

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainActivity.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainActivity.kt
@@ -37,7 +37,7 @@ private val jsonResponseParser = object : ResponseParser {
     override fun <T : Any> parseSafe(text: String, kClass: KClass<T>): T? {
         return try {
             parse(text, kClass)
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             null
         }
     }
@@ -48,7 +48,7 @@ private val jsonResponseParser = object : ResponseParser {
             try {
                 // If it has a serializer, encode it safely via kotlinx.serialization
                 json.encodeToString(JsonElement.serializer(), json.parseToJsonElement(obj.toString()))
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 mapper.writeValueAsString(obj)
             }
         } else {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainActivity.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainActivity.kt
@@ -5,35 +5,61 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.lagradost.nicehttp.Requests
 import com.lagradost.nicehttp.ResponseParser
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.serializer
 import kotlin.reflect.KClass
 
 // Short name for requests client to make it nicer to use
-private val jacksonResponseParser = object : ResponseParser {
+@OptIn(ExperimentalSerializationApi::class)
+private val jsonResponseParser = object : ResponseParser {
     val mapper: ObjectMapper = jacksonObjectMapper().configure(
         DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
         false
     )
 
+    val json = Json { ignoreUnknownKeys = true }
+
     override fun <T : Any> parse(text: String, kClass: KClass<T>): T {
-        return mapper.readValue(text, kClass.java)
+        val serializer = json.serializersModule.getContextual(kClass)
+        return if (serializer != null) {
+            try {
+                json.decodeFromString(serializer, text)
+            } catch (_: Exception) {
+                mapper.readValue(text, kClass.java)
+            }
+        } else {
+            mapper.readValue(text, kClass.java)
+        }
     }
 
     override fun <T : Any> parseSafe(text: String, kClass: KClass<T>): T? {
         return try {
-            mapper.readValue(text, kClass.java)
+            parse(text, kClass)
         } catch (e: Exception) {
             null
         }
     }
 
     override fun writeValueAsString(obj: Any): String {
-        return mapper.writeValueAsString(obj)
+        val serializer = json.serializersModule.getContextual(obj::class)
+        return if (serializer != null) {
+            try {
+                // If it has a serializer, encode it safely via kotlinx.serialization
+                json.encodeToString(JsonElement.serializer(), json.parseToJsonElement(obj.toString()))
+            } catch (e: Exception) {
+                mapper.writeValueAsString(obj)
+            }
+        } else {
+            mapper.writeValueAsString(obj)
+        }
     }
 }
 
 /** The default networking helper. This helper performs SSL checks.
  * If you need to make requests to websites with invalid SSL certificates use insecureApp instead. */
-var app = Requests(responseParser = jacksonResponseParser).apply {
+var app = Requests(responseParser = jsonResponseParser).apply {
     defaultHeaders = mapOf("user-agent" to USER_AGENT)
 }
 
@@ -41,6 +67,6 @@ var app = Requests(responseParser = jacksonResponseParser).apply {
  * This should NEVER be used for sensitive networking operations such as logins. Only use this when required. */
 @Prerelease
 @UnsafeSSL
-var insecureApp = Requests(responseParser = jacksonResponseParser).apply {
+var insecureApp = Requests(responseParser = jsonResponseParser).apply {
     defaultHeaders = mapOf("user-agent" to USER_AGENT)
 }


### PR DESCRIPTION
If accepted, I will slowly migrate the app and library to kotlinx-serialization, standardizing all the different JSON parsers we use as well. kotlinx-serialization is fully KMP and also more performant, because unlike Jackson, it doesn't use runtime reflection, it uses validation at compiler time.