### PR TITLE
ExtractorAPI: use Kotlin Uuid

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -317,6 +317,7 @@ tasks.withType<KotlinJvmCompile> {
         optIn.addAll(
             "com.lagradost.cloudstream3.InternalAPI",
             "com.lagradost.cloudstream3.Prerelease",
+            "kotlin.uuid.ExperimentalUuidApi",
         )
     }
 }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -118,6 +118,8 @@ import java.util.concurrent.Executors
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSession
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 const val TAG = "CS3ExoPlayer"
 const val PREFERRED_AUDIO_LANGUAGE_KEY = "preferred_audio_language"
@@ -245,6 +247,11 @@ class CS3IPlayer : IPlayer {
             isPlayerActive = true
             activePlayers += 1
         }
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    private fun Uuid.toJavaUUID(): UUID {
+        return UUID(mostSignificantBits, leastSignificantBits)
     }
 
     fun String.stripTrackId(): String {
@@ -1278,7 +1285,7 @@ class CS3IPlayer : IPlayer {
 
             item.drm?.let { drm ->
                 when (drm.uuid) {
-                    CLEARKEY_UUID -> {
+                    CLEARKEY_UUID.toJavaUUID() -> {
                         // Use headers from DrmMetadata for media requests
                         val client = dataSourceFactory
                             ?: throw IllegalArgumentException("Must supply onlineSource")
@@ -1299,8 +1306,8 @@ class CS3IPlayer : IPlayer {
                             .createMediaSource(item.mediaItem)
                     }
 
-                    WIDEVINE_UUID,
-                    PLAYREADY_UUID -> {
+                    WIDEVINE_UUID.toJavaUUID(),
+                    PLAYREADY_UUID.toJavaUUID() -> {
                         // Use headers from DrmMetadata for media requests
                         val client = dataSourceFactory
                             ?: throw IllegalArgumentException("Must supply onlineSource")

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalUuidApi::class)
+@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
 @file:Suppress("DEPRECATION")
 
 package com.lagradost.cloudstream3.ui.player

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -1921,7 +1921,7 @@ class CS3IPlayer : IPlayer {
                             drm = DrmMetadata(
                                 kid = link.kid,
                                 key = link.key,
-                                uuid = link.uuid,
+                                uuid = link.uuid.toJavaUUID(),
                                 kty = link.kty,
                                 licenseUrl = link.licenseUrl,
                                 keyRequestParameters = link.keyRequestParameters,

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -1,5 +1,5 @@
-@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
 @file:Suppress("DEPRECATION")
+@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
 
 package com.lagradost.cloudstream3.ui.player
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -251,7 +251,7 @@ class CS3IPlayer : IPlayer {
     }
 
     private fun Uuid.toJavaUUID(): UUID {
-        return UUID(mostSignificantBits, leastSignificantBits)
+        return UUID.fromString(this.toString())
     }
 
     fun String.stripTrackId(): String {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -1,5 +1,4 @@
 @file:Suppress("DEPRECATION")
-@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
 
 package com.lagradost.cloudstream3.ui.player
 
@@ -119,7 +118,6 @@ import java.util.concurrent.Executors
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSession
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 const val TAG = "CS3ExoPlayer"

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -1,3 +1,4 @@
+@file:OptIn(ExperimentalUuidApi::class)
 @file:Suppress("DEPRECATION")
 
 package com.lagradost.cloudstream3.ui.player
@@ -249,7 +250,6 @@ class CS3IPlayer : IPlayer {
         }
     }
 
-    @OptIn(ExperimentalUuidApi::class)
     private fun Uuid.toJavaUUID(): UUID {
         return UUID(mostSignificantBits, leastSignificantBits)
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
@@ -5,6 +5,7 @@ package com.lagradost.cloudstream3.utils
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.lagradost.cloudstream3.AudioFile
 import com.lagradost.cloudstream3.IDownloadableMinimum
+import com.lagradost.cloudstream3.Prerelease
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.USER_AGENT
 import com.lagradost.cloudstream3.app
@@ -511,6 +512,7 @@ suspend fun newDrmExtractorLink(
     return builder
 }
 
+@Prerelease
 suspend fun newDrmExtractorLink(
     source: String,
     name: String,

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
@@ -480,7 +480,11 @@ suspend fun newExtractorLink(
     return builder
 }
 
-// Deprecate
+// Deprecate after next stable
+/* @Deprecated(
+    message = "Use Kotlin Uuid (kotlin.uuid.Uuid) instead of Java UUID.",
+    level = DeprecationLevel.WARNING,
+) */
 suspend fun newDrmExtractorLink(
     source: String,
     name: String,

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
 package com.lagradost.cloudstream3.utils
 
 import com.fasterxml.jackson.annotation.JsonIgnore
@@ -316,6 +318,8 @@ import org.jsoup.Jsoup
 import java.net.URI
 import java.util.UUID
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 /**
  * For use in the ConcatenatingMediaSource.
@@ -431,29 +435,29 @@ private fun inferTypeFromUrl(url: String): ExtractorLinkType {
 val INFER_TYPE: ExtractorLinkType? = null
 
 /**
- * UUID for the ClearKey DRM scheme.
+ * [Uuid] for the ClearKey DRM scheme.
  *
  *
  * ClearKey is supported on Android devices running Android 5.0 (API Level 21) and up.
  */
-val CLEARKEY_UUID = UUID(-0x1d8e62a7567a4c37L, 0x781AB030AF78D30EL)
+val CLEARKEY_UUID = Uuid.fromLongs(-0x1d8e62a7567a4c37L, 0x781AB030AF78D30EL)
 
 /**
- * UUID for the Widevine DRM scheme.
+ * [Uuid] for the Widevine DRM scheme.
  *
  *
  * Widevine is supported on Android devices running Android 4.3 (API Level 18) and up.
  */
-val WIDEVINE_UUID = UUID(-0x121074568629b532L, -0x5c37d8232ae2de13L)
+val WIDEVINE_UUID = Uuid.fromLongs(-0x121074568629b532L, -0x5c37d8232ae2de13L)
 
 /**
- * UUID for the PlayReady DRM scheme.
+ * [Uuid] for the PlayReady DRM scheme.
  *
  *
  * PlayReady is supported on all AndroidTV devices. Note that most other Android devices do not
  * provide PlayReady support.
  */
-val PLAYREADY_UUID = UUID(-0x65fb0f8667bfbd7aL, -0x546d19a41f77a06bL)
+val PLAYREADY_UUID = Uuid.fromLongs(-0x65fb0f8667bfbd7aL, -0x546d19a41f77a06bL)
 
 suspend fun newExtractorLink(
     source: String,
@@ -476,6 +480,7 @@ suspend fun newExtractorLink(
     return builder
 }
 
+// Deprecate
 suspend fun newDrmExtractorLink(
     source: String,
     name: String,
@@ -484,7 +489,32 @@ suspend fun newDrmExtractorLink(
     uuid: UUID,
     initializer: suspend DrmExtractorLink.() -> Unit = { }
 ): DrmExtractorLink {
+    fun UUID.toKotlinUuid(): Uuid {
+        return Uuid.fromLongs(mostSignificantBits, leastSignificantBits)
+    }
 
+    @Suppress("DEPRECATION_ERROR")
+    val builder =
+        DrmExtractorLink(
+            source = source,
+            name = name,
+            url = url,
+            uuid = uuid.toKotlinUuid(),
+            type = type ?: INFER_TYPE
+        )
+
+    builder.initializer()
+    return builder
+}
+
+suspend fun newDrmExtractorLink(
+    source: String,
+    name: String,
+    url: String,
+    type: ExtractorLinkType? = null,
+    uuid: Uuid,
+    initializer: suspend DrmExtractorLink.() -> Unit = { }
+): DrmExtractorLink {
     @Suppress("DEPRECATION_ERROR")
     val builder =
         DrmExtractorLink(
@@ -510,7 +540,7 @@ suspend fun newDrmExtractorLink(
  * @property type the type of the media, use [INFER_TYPE] if you want to auto infer the type from the url
  * @property kid  Base64 value of The KID element (Key Id) contains the identifier of the key associated with a license.
  * @property key Base64 value of Key to be used to decrypt the media file.
- * @property uuid Drm UUID [WIDEVINE_UUID], [PLAYREADY_UUID], [CLEARKEY_UUID] (by default) .. etc
+ * @property uuid Drm [Uuid] [WIDEVINE_UUID], [PLAYREADY_UUID], [CLEARKEY_UUID] (by default) .. etc
  * @property kty Key type "oct" (octet sequence) by default
  * @property keyRequestParameters Parameters that will used to request the key.
  * @see newDrmExtractorLink
@@ -528,7 +558,7 @@ open class DrmExtractorLink private constructor(
     override var type: ExtractorLinkType,
     open var kid: String? = null,
     open var key: String? = null,
-    open var uuid: UUID,
+    open var uuid: Uuid,
     open var kty: String? = null,
     open var keyRequestParameters: HashMap<String, String>,
     open var licenseUrl: String? = null,
@@ -550,7 +580,7 @@ open class DrmExtractorLink private constructor(
         extractorData: String? = null,
         kid: String? = null,
         key: String? = null,
-        uuid: UUID = CLEARKEY_UUID,
+        uuid: Uuid = CLEARKEY_UUID,
         kty: String? = "oct",
         keyRequestParameters: HashMap<String, String> = hashMapOf(),
         licenseUrl: String? = null,
@@ -585,7 +615,7 @@ open class DrmExtractorLink private constructor(
         extractorData: String? = null,
         kid: String? = null,
         key: String? = null,
-        uuid: UUID = CLEARKEY_UUID,
+        uuid: Uuid = CLEARKEY_UUID,
         kty: String? = "oct",
         keyRequestParameters: HashMap<String, String> = hashMapOf(),
         licenseUrl: String? = null,

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/HlsPlaylistParser.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/HlsPlaylistParser.kt
@@ -1179,7 +1179,7 @@ object HlsPlaylistParser {
         if (KEYFORMAT_WIDEVINE_PSSH_BINARY == keyFormat) {
             val uriString = parseStringAttr(line, REGEX_URI, variableDefinitions)
             return SchemeData(
-                uuid = WIDEVINE_UUID,
+                uuid = C.WIDEVINE_UUID,
                 mimeType = MimeTypes.VIDEO_MP4,
                 data = Base64.Default.decode(uriString.substring(uriString.indexOf(',')))
             )


### PR DESCRIPTION
I didn't find any extensions using the variables directly, so doesn't keep back compat there, as it was very hard to because of the way CS3IPlayer uses them etc... I decided not to change `DrmMetadata` to use the Kotlin Uuid and just convert all usage in CS3IPlayer to Java UUIDs for now. We could eventually change `DrmMetadata` to Kotlin Uuid though, and just convert to Java in one single place for Media3 but I figured that was out of scope and this accomplish the main goal of supporting Kotlin Uuid in the main API surface. This, combined with some of my other PRs accomplish the majority of the remaining API surface migrations, so I wanted to get it done before next stable also.

I added a global OptIn for `kotlin.uuid.ExperimentalUuidApi` in `:app` only because adding it as `@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)` doesn't work for some reason though it does in library and would for extensions. This also will no longer be necessary at all in Kotlin 2.4, but I just wanted to do this now so that the API surface is updated and we can support the new version for the next stable release.

If there is some changes or suggestions needed for this I am happy to make those.