### PR TITLE
Use androidx.core:core rather than -ktx version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -216,7 +216,7 @@ dependencies {
     // Testing
     testImplementation(libs.junit)
     testImplementation(libs.json)
-    androidTestImplementation(libs.core)
+    androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.espresso.core)
     androidTestImplementation(libs.ext.junit)
     androidTestImplementation(libs.instancio.core)
@@ -224,8 +224,8 @@ dependencies {
     androidTestImplementation(libs.kotlin.test)
 
     // Android Core & Lifecycle
-    implementation(libs.core.ktx)
     implementation(libs.activity.ktx)
+    implementation(libs.androidx.core)
     implementation(libs.annotation)
     implementation(libs.appcompat)
     implementation(libs.fragment.ktx)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,8 @@
 [versions]
 activityKtx = "1.13.0"
 androidGradlePlugin = "9.1.1"
+androidxCore = "1.18.0"
+androidxTestCore = "1.7.0"
 animeDb = "1.0.2"
 annotation = "1.10.0"
 appcompat = "1.7.1"
@@ -12,7 +14,6 @@ coil = { strictly = "3.3.0" } # Later versions require jvmTarget 11 or later
 colorpicker = "6b46b49"
 conscryptAndroid = { strictly = "2.5.2" } # 2.5.3 crashes everything
 constraintlayout = "2.2.1"
-coreKtx = "1.18.0"
 cryptography = "0.6.0"
 desugar_jdk_libs_nio = "2.1.5"
 dokkaGradlePlugin = "2.2.0"
@@ -67,6 +68,8 @@ versionName = "4.7.0"
 
 [libraries]
 activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activityKtx" }
+androidx-core = { module = "androidx.core:core", version.ref = "androidxCore" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTestCore" }
 anime-db = { module = "com.github.recloudstream:anime-db", version.ref = "animeDb" }
 annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
@@ -76,8 +79,6 @@ coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version
 colorpicker = { module = "com.github.recloudstream:color-picker-android", version.ref = "colorpicker" }
 conscrypt-android = { module = "org.conscrypt:conscrypt-android", version.ref = "conscryptAndroid" }
 constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
-core = { module = "androidx.test:core" }
-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
 cryptography-core = { module = "dev.whyoleg.cryptography:cryptography-core", version.ref = "cryptography" }
 cryptography-provider-optimal = { module = "dev.whyoleg.cryptography:cryptography-provider-optimal", version.ref = "cryptography" }
 databinding = { module = "androidx.databinding:viewbinding", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
Starting in 1.19.0 the ktx version is deprecated. We can replace now anyway. Needs compileSdk 37 in order to bump to 1.19.0 though.