### PR TITLE
Use api() for some dependencies in library

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -226,7 +226,7 @@ dependencies {
     // Android Core & Lifecycle
     implementation(libs.core.ktx)
     implementation(libs.activity.ktx)
-    implementation(libs.annotation)
+    implementation(libs.androidx.annotation)
     implementation(libs.appcompat)
     implementation(libs.fragment.ktx)
     implementation(libs.bundles.lifecycle)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 [versions]
 activityKtx = "1.13.0"
 androidGradlePlugin = "9.1.1"
+androidxAnnotation = "1.10.0"
 animeDb = "1.0.2"
-annotation = "1.10.0"
 appcompat = "1.7.1"
 biometric = "1.4.0-alpha07"
 buildkonfigGradlePlugin = "0.21.2"
@@ -67,8 +67,8 @@ versionName = "4.7.0"
 
 [libraries]
 activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activityKtx" }
+androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidxAnnotation" }
 anime-db = { module = "com.github.recloudstream:anime-db", version.ref = "animeDb" }
-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 biometric = { module = "androidx.biometric:biometric", version.ref = "biometric" }
 coil = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -56,19 +56,20 @@ kotlin {
         }
 
         commonMain.dependencies {
-            implementation(libs.annotation) // Annotations
+            api(libs.annotation) // Annotations
+            api(libs.kotlinx.atomicfu)
+            api(libs.kotlinx.coroutines.core)
+            api(libs.kotlinx.datetime)
+            api(libs.kotlinx.serialization.json) // JSON Parser
+            api(libs.ksoup) // HTML Parser
+            api(libs.ktor.http)
+            api(libs.nicehttp) // HTTP Library
+            api(libs.bundles.cryptography) // Cryptography
+
             implementation(libs.jackson.module.kotlin) // JSON Parser
             implementation(libs.jsoup) // HTML Parser
-            implementation(libs.kotlinx.atomicfu)
-            implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kotlinx.datetime)
-            implementation(libs.kotlinx.serialization.json) // JSON Parser
-            implementation(libs.ksoup) // HTML Parser
-            implementation(libs.ktor.http)
-            implementation(libs.nicehttp) // HTTP Library
             implementation(libs.rhino) // Run JavaScript
             implementation(libs.tmdb.java) // TMDB API v3 Wrapper Made with RetroFit
-            implementation(libs.bundles.cryptography) // Cryptography
 
             // Deprecated; will be removed once extensions have time to migrate from using it
             implementation("me.xdrop:fuzzywuzzy:1.4.0")

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -57,7 +57,6 @@ kotlin {
 
         commonMain.dependencies {
             api(libs.androidx.annotation) // Annotations
-            api(libs.bundles.cryptography) // Cryptography
             api(libs.kotlinx.atomicfu)
             api(libs.kotlinx.coroutines.core)
             api(libs.kotlinx.datetime)
@@ -65,6 +64,8 @@ kotlin {
             api(libs.ksoup) // HTML Parser
             api(libs.ktor.http)
             api(libs.nicehttp) // HTTP Library
+
+            api(libs.bundles.cryptography) // Cryptography
 
             implementation(libs.jackson.module.kotlin) // JSON Parser
             implementation(libs.jsoup) // HTML Parser

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -56,7 +56,8 @@ kotlin {
         }
 
         commonMain.dependencies {
-            api(libs.annotation) // Annotations
+            api(libs.androidx.annotation) // Annotations
+            api(libs.bundles.cryptography) // Cryptography
             api(libs.kotlinx.atomicfu)
             api(libs.kotlinx.coroutines.core)
             api(libs.kotlinx.datetime)
@@ -64,7 +65,6 @@ kotlin {
             api(libs.ksoup) // HTML Parser
             api(libs.ktor.http)
             api(libs.nicehttp) // HTTP Library
-            api(libs.bundles.cryptography) // Cryptography
 
             implementation(libs.jackson.module.kotlin) // JSON Parser
             implementation(libs.jsoup) // HTML Parser

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -64,7 +64,6 @@ kotlin {
             api(libs.ksoup) // HTML Parser
             api(libs.ktor.http)
             api(libs.nicehttp) // HTTP Library
-
             api(libs.bundles.cryptography) // Cryptography
 
             implementation(libs.jackson.module.kotlin) // JSON Parser


### PR DESCRIPTION
Would allow extensions to use them without having to add the dependencies themselves. Ones that we have actual public APIs that use them should be used like this. Allows us to better keep versions in sync also.