### PR TITLE
Remove `failOnNoDiscoveredTests = false`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,10 +8,3 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.kotlin.serialization) apply false
 }
-
-allprojects {
-    // https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#test_task_fails_when_no_tests_are_discovered
-    tasks.withType<AbstractTestTask>().configureEach {
-        failOnNoDiscoveredTests = false
-    }
-}


### PR DESCRIPTION
Not needed anymore since we actually have tests now.